### PR TITLE
Make the board copy less bad

### DIFF
--- a/pkg/lookahead/lookahead.go
+++ b/pkg/lookahead/lookahead.go
@@ -2,11 +2,11 @@ package lookahead
 
 import (
 	"fmt"
-	"github.com/SamWheating/battlesnake2020/pkg/heuristics"
-	"github.com/SamWheating/battlesnake2020/pkg/structs"
-	"github.com/getlantern/deepcopy"
 	"math/rand"
 	"time"
+
+	"github.com/SamWheating/battlesnake2020/pkg/heuristics"
+	"github.com/SamWheating/battlesnake2020/pkg/structs"
 )
 
 func Lookahead(state structs.MoveRequest, depth int, count int) string {
@@ -92,13 +92,7 @@ func SampleRandomSnakeMoves(board structs.Board, depth int, count int) []map[str
 //   3) Eat food
 //   4) Check for wall collisions + starvations
 func ApplyMovesToBoard(moves map[string][]string, board structs.Board) structs.Board {
-	// snake1: [left, right, down]
-	boardBoard := new(structs.Board)
-	err := deepcopy.Copy(boardBoard, &board)
-	if err != nil {
-		fmt.Println(err)
-	}
-	newBoard := *boardBoard
+	newBoard := board.Clone()
 
 	for i := range moves[newBoard.Snakes[0].ID] { // [left, right, down]
 		snakes := []structs.Snake{}

--- a/pkg/structs/types.go
+++ b/pkg/structs/types.go
@@ -51,6 +51,14 @@ func (c Coordinate) Move(dir string) Coordinate {
 	}
 }
 
+func (c Coordinate) Clone() Coordinate {
+	result := Coordinate{
+		X: c.X,
+		Y: c.Y,
+	}
+	return result
+}
+
 type MoveResponse struct {
 	Move  string
 	Shout string
@@ -87,12 +95,47 @@ type Board struct {
 	Snakes []Snake      `json:"snakes"`
 }
 
+func (b Board) Clone() Board {
+	result := Board{
+		Height: b.Height,
+		Width:  b.Width,
+		Food:   []Coordinate{},
+		Snakes: []Snake{},
+	}
+
+	for _, coord := range b.Food {
+		result.Food = append(result.Food, coord.Clone())
+	}
+
+	for _, snake := range b.Snakes {
+		result.Snakes = append(result.Snakes, snake.Clone())
+	}
+
+	return result
+}
+
 type Snake struct {
 	ID     string       `json:"id"`
 	Name   string       `json:"name"`
 	Health int          `json:"health"`
 	Body   []Coordinate `json:"body"`
 	Shout  string       `json:"shout"`
+}
+
+func (s Snake) Clone() Snake {
+	result := Snake{
+		ID:     s.ID,
+		Name:   s.Name,
+		Health: s.Health,
+		Body:   []Coordinate{},
+		Shout:  s.Shout,
+	}
+
+	for _, coord := range s.Body {
+		result.Body = append(result.Body, coord.Clone())
+	}
+
+	return result
 }
 
 // This is the request structure from the gameserver -


### PR DESCRIPTION
See https://github.com/SamWheating/battlesnake2020/issues/4

I made clone functions for each of the structs involved to cut down on the time spent marshalling/unmarshalling json. Probably still room for improvement but this cuts `lookahead.ApplyMovesToBoard` down quite a bit.