### PR TITLE
Invert y axis as per API v1->2

### DIFF
--- a/pkg/heuristics/heuristics_test.go
+++ b/pkg/heuristics/heuristics_test.go
@@ -78,40 +78,28 @@ func TestFloodFillSomeEmpty(t *testing.T) {
 
 func TestHeadRoom(t *testing.T) {
 
-	request := structs.MoveRequest{
-		You: structs.Snake{
-			Body: []structs.Coordinate{
-				structs.Coordinate{
-					X: 0,
-					Y: 1,
-				},
-				structs.Coordinate{
-					X: 1,
-					Y: 1,
-				},
-			},
-		},
-		Board: structs.Board{
-			Height: 2,
-			Width:  2,
-			Snakes: []structs.Snake{
-				structs.Snake{
-					Body: []structs.Coordinate{
-						structs.Coordinate{
-							X: 0,
-							Y: 1,
-						},
-						structs.Coordinate{
-							X: 1,
-							Y: 1,
-						},
+	board := structs.Board{
+		Height: 2,
+		Width:  2,
+		Snakes: []structs.Snake{
+			structs.Snake{
+				Health: 100,
+				ID:     "snake",
+				Body: []structs.Coordinate{
+					structs.Coordinate{
+						X: 0,
+						Y: 1,
+					},
+					structs.Coordinate{
+						X: 1,
+						Y: 1,
 					},
 				},
 			},
 		},
 	}
 
-	got := heuristics.HeadRoom(request)
+	got := heuristics.HeadRoom(board, "snake")
 	if got != 3 {
 		t.Errorf("Floodfilled to %d, expected 3", got)
 	}
@@ -119,53 +107,41 @@ func TestHeadRoom(t *testing.T) {
 
 func TestHeadRoomFullBoard(t *testing.T) {
 
-	request := structs.MoveRequest{
-		You: structs.Snake{
-			Body: []structs.Coordinate{
-				structs.Coordinate{
-					X: 0,
-					Y: 1,
-				},
-				structs.Coordinate{
-					X: 1,
-					Y: 1,
-				},
-			},
-		},
-		Board: structs.Board{
-			Height: 2,
-			Width:  2,
-			Snakes: []structs.Snake{
-				structs.Snake{
-					Body: []structs.Coordinate{
-						structs.Coordinate{
-							X: 0,
-							Y: 1,
-						},
-						structs.Coordinate{
-							X: 1,
-							Y: 1,
-						},
+	board := structs.Board{
+		Height: 2,
+		Width:  2,
+		Snakes: []structs.Snake{
+			structs.Snake{
+				Body: []structs.Coordinate{
+					structs.Coordinate{
+						X: 0,
+						Y: 1,
+					},
+					structs.Coordinate{
+						X: 1,
+						Y: 1,
 					},
 				},
-				structs.Snake{
-					Body: []structs.Coordinate{
-						structs.Coordinate{
-							X: 0,
-							Y: 0,
-						},
-						structs.Coordinate{
-							X: 1,
-							Y: 0,
-						},
+			},
+			structs.Snake{
+				ID:     "snek",
+				Health: 100,
+				Body: []structs.Coordinate{
+					structs.Coordinate{
+						X: 0,
+						Y: 0,
+					},
+					structs.Coordinate{
+						X: 1,
+						Y: 0,
 					},
 				},
 			},
 		},
 	}
 
-	got := heuristics.HeadRoom(request)
-	if got != 1 {
-		t.Errorf("Floodfilled to %d, expected 3", got)
+	got := heuristics.HeadRoom(board, "snek")
+	if got != 0 {
+		t.Errorf("Floodfilled to %d, expected 0", got)
 	}
 }

--- a/pkg/lookahead/lookahead_test.go
+++ b/pkg/lookahead/lookahead_test.go
@@ -7,57 +7,6 @@ import (
 	"github.com/SamWheating/battlesnake2020/pkg/structs"
 )
 
-func TestNextBoards(t *testing.T) {
-	state := structs.MoveRequest{
-		Game: structs.Game{
-			ID: "666",
-		},
-		Turn: 4,
-		You: structs.Snake{
-			Body: []structs.Coordinate{
-				{
-					X: 0,
-					Y: 1,
-				}, {
-					X: 1,
-					Y: 1,
-				},
-			},
-		},
-		Board: structs.Board{
-			Height: 2,
-			Width:  2,
-			Snakes: []structs.Snake{
-				{
-					Body: []structs.Coordinate{
-						{
-							X: 0,
-							Y: 1,
-						}, {
-							X: 1,
-							Y: 1,
-						},
-					},
-				}, {
-					Body: []structs.Coordinate{
-						{
-							X: 3,
-							Y: 4,
-						}, {
-							X: 3,
-							Y: 5,
-						},
-					},
-				},
-			},
-		},
-	}
-
-	for board := range lookahead.NextBoards(state, 4) {
-		t.Logf("The turn is...%+v", board)
-	}
-}
-
 func TestIsStarved(t *testing.T) {
 	snake := structs.Snake{
 		Health: 100,
@@ -289,20 +238,6 @@ func TestApplyMovesToBoardMovesOneSnakeHitsWall(t *testing.T) {
 	}
 	if nextboard.Snakes[0].ID == "lost" {
 		t.Errorf("The wrong snake died")
-	}
-}
-
-func TestGetSnakeMoves(t *testing.T) {
-	board := structs.Board{
-		Snakes: []structs.Snake{
-			structs.Snake{
-				ID: "snake1",
-			},
-		},
-	}
-	moves := lookahead.GetSnakeMoves(board, 1)
-	if len(moves) != 4 {
-		t.Errorf("Actual output not as expected")
 	}
 }
 

--- a/pkg/structs/types.go
+++ b/pkg/structs/types.go
@@ -25,7 +25,7 @@ func (c Coordinate) Right() Coordinate {
 func (c Coordinate) Up() Coordinate {
 	result := Coordinate{
 		X: c.X,
-		Y: c.Y - 1,
+		Y: c.Y + 1,
 	}
 	return result
 }
@@ -33,7 +33,7 @@ func (c Coordinate) Up() Coordinate {
 func (c Coordinate) Down() Coordinate {
 	result := Coordinate{
 		X: c.X,
-		Y: c.Y + 1,
+		Y: c.Y - 1,
 	}
 	return result
 }


### PR DESCRIPTION
#### In this PR:

 - inverting the Y axis for API v2 compatibility
 - refactoring broken tests, removing tests for code that was removed

[I tested this on the global snake arena](https://play.battlesnake.com/g/05b24f5c-6643-45c1-9174-071acd39048a/) with [ngrok](https://ngrok.com/) and it seemed to work, the snake dies after ~100 moves but I suspect that was throttling from ngrok's free / unregistered tier. 