### PR TITLE
scale down to 3/1000 on an F1

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -1,2 +1,2 @@
 runtime: go112 # replace with go111 for Go 1.11
-instance_class: F4
+instance_class: F1

--- a/pkg/handlers/handlers.go
+++ b/pkg/handlers/handlers.go
@@ -71,10 +71,10 @@ func Move(w http.ResponseWriter, r *http.Request) {
 	depthArg := r.URL.Query().Get("depth")
 	countArg := r.URL.Query().Get("count")
 	if depthArg == "" {
-		depthArg = "5"
+		depthArg = "3"
 	}
 	if countArg == "" {
-		countArg = "5000"
+		countArg = "1000"
 	}
 	depth, _ := strconv.Atoi(depthArg)
 	count, _ := strconv.Atoi(countArg)


### PR DESCRIPTION
Looks like I've torched the free-tier for this month so I'm gonna scale down a bit.

The free tier gives us 28 F instance hours / day, aggregated monthly. So we can use an F1 for the whole month and then scale up to an F4 or whatever if we want to more actively test / experiment for a few days. 

I have already deployed these changes to app engine (`gcloud app deploy`)